### PR TITLE
Add c8g node group

### DIFF
--- a/terraform-aws-eks-europe/main.tf
+++ b/terraform-aws-eks-europe/main.tf
@@ -206,6 +206,21 @@ locals {
           effect = "NO_SCHEDULE"
         }
       ]
+    },
+    "c8g-4xlarge-dedi" : {
+      instance_types = ["c8g.4xlarge"]
+
+      labels = {
+        "zeet.co/dedicated" = "dedicated"
+      }
+
+      taints = [
+        {
+          key    = "zeet.co/dedicated"
+          value  = "dedicated"
+          effect = "NO_SCHEDULE"
+        }
+      ]
     }
     "c5-xlarge-guran" : {
       instance_types = ["c5.xlarge"]


### PR DESCRIPTION
### TL;DR
Added a new dedicated node group for c8g.4xlarge instance type in EKS cluster

### What changed?
Added a new node group configuration "c8g-4xlarge-dedi" that uses c8g.4xlarge instances with dedicated labels and NO_SCHEDULE taints

### How to test?
1. Apply the terraform changes
2. Verify the new node group is created in EKS
3. Attempt to schedule a pod with matching tolerations to the new node group
4. Confirm pods without matching tolerations cannot schedule to these nodes

### Why make this change?
To provide dedicated compute resources using Graviton-based instances (c8g.4xlarge) for workloads that require isolation and ARM64 architecture