### PR TITLE
add node group role perms

### DIFF
--- a/terraform-aws-eks-insight/main.tf
+++ b/terraform-aws-eks-insight/main.tf
@@ -337,6 +337,11 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     disk_size = 100
+    
+    # Attach additional policies to all node group roles
+    role_additional_policies = {
+      Warpstream_Insight_Production = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/Warpstream_Insight_Production"
+    }
   }
 
   eks_managed_node_groups = local.worker_templates_cpu
@@ -407,6 +412,7 @@ resource "aws_autoscaling_group_tag" "eks_managed_node_groups" {
     propagate_at_launch = each.value.propagate_at_launch
   }
 }
+
 resource "aws_eks_addon" "eks_addon_csi" {
   cluster_name             = module.eks.cluster_id
   service_account_role_arn = module.iam_ebs-csi.this_iam_role_arn

--- a/terraform-aws-eks-insight/main.tf
+++ b/terraform-aws-eks-insight/main.tf
@@ -339,7 +339,7 @@ module "eks" {
     disk_size = 100
     
     # Attach additional policies to all node group roles
-    role_additional_policies = {
+    iam_role_additional_policies = {
       Warpstream_Insight_Production = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/Warpstream_Insight_Production"
     }
   }

--- a/terraform-aws-eks-insight/outputs.tf
+++ b/terraform-aws-eks-insight/outputs.tf
@@ -12,6 +12,11 @@ output "self_managed_node_groups_role" {
   value = values(module.eks.self_managed_node_groups)[*].iam_role_arn
 }
 
+output "eks_managed_node_groups_role_arns" {
+  description = "IAM role ARNs for EKS managed node groups"
+  value       = { for k, v in module.eks.eks_managed_node_groups : k => v.iam_role_arn }
+}
+
 output "region" {
   description = "AWS region."
   value       = var.region


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow attaching additional IAM policies to all EKS managed node group roles, enabling centralized policy management for node permissions.
  * Enable the AWS EBS CSI driver as a managed EKS add-on to provide persistent block storage support for pods.
  * Add a new output exposing IAM role ARNs for each managed node group to simplify role discovery and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->